### PR TITLE
Add CSV column to map permission for Viewer role on folder

### DIFF
--- a/example.csv
+++ b/example.csv
@@ -1,7 +1,7 @@
-ZBV/LDAP-Gruppe,Grafana-Team-Name,Grafana-Team-ID,Grafana-Folder-Name,Grafana-Folder-UUID,Grafana-Folder-Permissions
-mathematicians,mathematicians,2,math,math_folder,Admin
-mathematicians,smart people,2,all,all,View
-scientists,scientists,2,science,science_folder,Admin
-scientists,smart people,2,all,all,View
-chemists,chemists,2,chemistry,chemistry_folder,Admin
-chemists,smart people,2,all,all,View
+ZBV/LDAP-Gruppe,Grafana-Team-Name,Grafana-Team-ID,Grafana-Folder-Name,Grafana-Folder-UUID,Grafana-Folder-Permissions,Grafana-Folder-Permissions-For-Viewer
+mathematicians,mathematicians,2,math,math_folder,Admin,View
+mathematicians,smart people,2,all,all,View,View
+scientists,scientists,2,science,science_folder,Admin,
+scientists,smart people,2,all,all,View,
+chemists,chemists,2,chemistry,chemistry_folder,Admin,
+chemists,smart people,2,all,all,View,

--- a/script/core.py
+++ b/script/core.py
@@ -69,6 +69,7 @@ def read_mapping_from_csv(bind):
             folder_name = line[3]
             folder_uuid = line[4]
             permission = line[5]
+            permission_for_viewer = line[6]
             if not team in result["teams"]:
                 result["teams"][team] = {"ldap": []}
             if not ldap in result["teams"][team]["ldap"]:
@@ -78,6 +79,9 @@ def read_mapping_from_csv(bind):
             access = {"teamId": team, "permission": permission}
             if not access in result["folders"][folder_uuid]["permissions"]:
                 result["folders"][folder_uuid]["permissions"].append(access)
+            viewer_access = {"role": "Viewer", "permission": permission_for_viewer}
+            if permission_for_viewer != "" and not viewer_access in result["folders"][folder_uuid]["permissions"]:
+                result["folders"][folder_uuid]["permissions"].append(viewer_access)
         else:
             is_header = False
     return result
@@ -175,7 +179,7 @@ def update_folders(folders):
             create_folder(folders[folder_id]["name"], folder_id)
         permissions = folders[folder_id]["permissions"]
         for permission in permissions:
-            permission["teamId"] = get_id_of_team(permission["teamId"])
+            permission["teamId"] = get_id_of_team(permission["teamId"]) if not "role" in permission else 0
             permission["permission"] = PERMISSION_MAP[permission["permission"]]
         update_folder_permissions(folder_id, permissions)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,16 +31,18 @@ class read_mapping_from_csv(TestCase):
                                        "header3",
                                        "header4",
                                        "header5",
-                                       "header6"],
+                                       "header6",
+                                       "header7"],
                                       ["test_ldap_group",
                                        "test_grafana_team",
                                        "test_grafana_team-id",
                                        "test_grafana_folder_name",
                                        "test_grafana_folder_uid",
-                                       "test_grafana_folder_permission"]
+                                       "test_grafana_folder_permission",
+                                       "test_grafana_folder_permission_for_viewer"]
                                       ]
 
-        mapping = core.read_mapping_from_csv()
+        mapping = core.read_mapping_from_csv("")
 
         self.assertTrue("teams" in mapping)
         self.assertTrue("test_grafana_team" in mapping["teams"])
@@ -51,7 +53,8 @@ class read_mapping_from_csv(TestCase):
         self.assertTrue("name" in mapping["folders"]["test_grafana_folder_uid"])
         self.assertTrue("permissions" in mapping["folders"]["test_grafana_folder_uid"])
         self.assertEqual("test_grafana_folder_name", mapping["folders"]["test_grafana_folder_uid"]["name"])
-        self.assertEqual([{"teamId": "test_grafana_team", "permission": "test_grafana_folder_permission"}],
+        self.assertEqual([{"teamId": "test_grafana_team", "permission": "test_grafana_folder_permission"},
+                        {"role": "Viewer", "permission": "test_grafana_folder_permission_for_viewer"}],
                          mapping["folders"]["test_grafana_folder_uid"]["permissions"])
 
 
@@ -379,7 +382,7 @@ class export(TestCase):
         mock_config.return_value = True
         mock_lock.return_value = True
 
-        core.startUserSync("")
+        core.startUserSync("", "", "")
 
         self.assertEqual(mock_lock.call_count, 1)
         self.assertEqual(mock_unlock.call_count, 1)
@@ -405,7 +408,7 @@ class export(TestCase):
         mock_config.return_value = True
         mock_lock.return_value = True
 
-        core.startUserSync("")
+        core.startUserSync("", "", "")
 
         self.assertEqual(mock_lock.call_count, 1)
         self.assertEqual(mock_unlock.call_count, 1)
@@ -432,7 +435,7 @@ class export(TestCase):
         mock_config.return_value = True
         mock_lock.return_value = True
 
-        core.startUserSync("")
+        core.startUserSync("", "", "")
 
         self.assertEqual(mock_lock.call_count, 1)
         self.assertEqual(mock_unlock.call_count, 1)
@@ -457,7 +460,7 @@ class export(TestCase):
         mock_config.return_value = True
         mock_lock.return_value = False
 
-        core.startUserSync("")
+        core.startUserSync("", "", "")
 
         self.assertEqual(mock_lock.call_count, 1)
         self.assertFalse(mock_remove_unused_items.called)


### PR DESCRIPTION
In my use-case, some folders should be editable by a specific LDAP group but should be viewable by any logged in user which has the Viewer role.

With this MR I'm adding support for an additional column in the CSV file to define the permission for the Viewer role on that folder.